### PR TITLE
Fixed the translation of word "Octave" in simplified & traditional Chinese

### DIFF
--- a/zh-cn.txt
+++ b/zh-cn.txt
@@ -59,8 +59,8 @@ language: 简体中文
   "Transpose..." = "变调..."
     "Transpose" = "变调"
       "Pitch shift (semitones)" = "音高移动 (半音)"
-  "Shift Up by an Octave" = "升高音阶"
-  "Shift Down by an Octave" = "降低音阶"
+  "Shift Up by an Octave" = "升高八度"
+  "Shift Down by an Octave" = "降低八度"
   "Merge into Group" = "创建音符组"
   "Disband Group" = "解散音符组"
 

--- a/zh-tw.txt
+++ b/zh-tw.txt
@@ -67,8 +67,8 @@ language: 繁體中文
   "Transpose..." = "變調至"
     "Transpose" = "變調"
       "Pitch shift (semitones)" = "音高移動 (半音)"
-  "Shift Up by an Octave" = "升高音階"
-  "Shift Down by an Octave" = "降低音階"
+  "Shift Up by an Octave" = "升高八度"
+  "Shift Down by an Octave" = "降低八度"
   "Merge into Group" = "整合進音符組"
   "Disband Group" = "解散音符組"
 


### PR DESCRIPTION
The word "Octave" should be translated to **八度** instead of 音阶（音階）.

According to Wikipedia &#40;[https://zh.wikipedia.org/wiki/八度](https://zh.wikipedia.org/wiki/%E5%85%AB%E5%BA%A6)&#41;&#58;

> 八度（英语：**Octave**，亦称为完全八度）是音程的一种